### PR TITLE
Accessorize

### DIFF
--- a/Ruby/Week 8/Accessorize/Gemfile
+++ b/Ruby/Week 8/Accessorize/Gemfile
@@ -1,0 +1,4 @@
+# Gemfile
+source "https://rubygems.org"
+
+gem "minitest"

--- a/Ruby/Week 8/Accessorize/Gemfile.lock
+++ b/Ruby/Week 8/Accessorize/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.14.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest
+
+BUNDLED WITH
+   1.17.2

--- a/Ruby/Week 8/Accessorize/accessorizable.rb
+++ b/Ruby/Week 8/Accessorize/accessorizable.rb
@@ -1,0 +1,21 @@
+module Accessorizable
+  attr_accessor :accessories
+
+  def add_accessory(text)
+    @accessories ||= []
+    @accessories << text
+  end
+
+  def remove_accessory(text)
+    @accessories.delete(text) unless @accessories.nil?
+  end
+
+  def accessories_to_s
+    return if @accessories.nil?
+
+    accessories_string = "accessories:"
+    @accessories.each { |accessory| accessories_string += "\n\t- #{accessory}" }
+
+    accessories_string
+  end
+end

--- a/Ruby/Week 8/Accessorize/ball.rb
+++ b/Ruby/Week 8/Accessorize/ball.rb
@@ -1,0 +1,11 @@
+require_relative 'toy'
+
+class Ball < Toy
+  def initialize(name)
+    super(name)
+  end
+
+  def to_s
+    "This is a ball, it's safe for children 6+."
+  end
+end

--- a/Ruby/Week 8/Accessorize/clothes.rb
+++ b/Ruby/Week 8/Accessorize/clothes.rb
@@ -1,0 +1,12 @@
+class Clothes
+  attr_reader :name, :color
+
+  def initialize(name, color)
+    @name = name
+    @color = color
+  end
+
+  def to_s
+    "This is a #{color} #{name}."
+  end
+end

--- a/Ruby/Week 8/Accessorize/potato_head.rb
+++ b/Ruby/Week 8/Accessorize/potato_head.rb
@@ -1,0 +1,14 @@
+require_relative 'toy'
+require_relative 'accessorizable'
+
+class MrPotatoHead < Toy
+  include Accessorizable
+
+  def initialize(name)
+    super(name)
+  end
+
+  def to_s
+    accessories_to_s
+  end
+end

--- a/Ruby/Week 8/Accessorize/shirt.rb
+++ b/Ruby/Week 8/Accessorize/shirt.rb
@@ -1,0 +1,14 @@
+require_relative 'clothes'
+require_relative 'accessorizable'
+
+class Shirt < Clothes
+  include Accessorizable
+
+  def initialize(name, color)
+    super(name, color)
+  end
+
+  def to_s
+    "A #{color} #{name}, with #{accessories_to_s}"
+  end
+end

--- a/Ruby/Week 8/Accessorize/tests/ball_test.rb
+++ b/Ruby/Week 8/Accessorize/tests/ball_test.rb
@@ -1,0 +1,17 @@
+require 'minitest/autorun'
+require_relative '../ball'
+
+class BallTest < Minitest::Test
+  def setup
+    @ball = Ball.new("Soccer ball")
+  end
+
+  def test_ball_initialized
+    assert_equal("Soccer ball", @ball.name)
+  end
+
+  def test_ball_string
+    expected = "This is a ball, it's safe for children 6+.\n"
+    assert_output(expected) { puts @ball.to_s }
+  end
+end

--- a/Ruby/Week 8/Accessorize/tests/clothes_test.rb
+++ b/Ruby/Week 8/Accessorize/tests/clothes_test.rb
@@ -1,0 +1,17 @@
+require 'minitest/autorun'
+require_relative '../clothes'
+
+class ClothesTest < Minitest::Test
+  def setup
+    @clothes = Clothes.new("T-shirt", "green")
+  end
+
+  def test_clothes_initialized
+    assert_equal("T-shirt", @clothes.name)
+  end
+
+  def test_to_s
+    expected = "This is a green T-shirt.\n"
+    assert_output(expected) { puts @clothes.to_s }
+  end
+end

--- a/Ruby/Week 8/Accessorize/tests/potato_head_test.rb
+++ b/Ruby/Week 8/Accessorize/tests/potato_head_test.rb
@@ -1,0 +1,60 @@
+require 'minitest/autorun'
+require_relative '../potato_head'
+
+class PotatoHeadTest < Minitest::Test
+  def setup
+    @potato_head = MrPotatoHead.new('Mr Potato Head')
+  end
+
+  def test_potato_head_initialized
+    assert_equal('Mr Potato Head', @potato_head.name)
+  end
+
+  def test_add_accessory
+    @potato_head.add_accessory('green hat')
+    expected = ['green hat']
+    assert_equal(expected, @potato_head.accessories)
+  end
+
+  def test_add_multiple_accessories
+    @potato_head.add_accessory('green hat')
+    @potato_head.add_accessory('red shoes')
+    @potato_head.add_accessory('orange ears')
+
+    expected = ['green hat', 'red shoes', 'orange ears']
+    assert_equal(expected, @potato_head.accessories)
+  end
+
+  def test_remove_accessory
+    @potato_head.add_accessory('green hat')
+    @potato_head.remove_accessory('green hat')
+    expected = []
+    assert_equal(expected, @potato_head.accessories)
+  end
+
+  def test_remove_accessory_that_does_not_exist
+    @potato_head.remove_accessory('green hat')
+    expected = nil
+    assert_nil(@potato_head.accessories)
+  end
+
+  def test_accessories_string
+    @potato_head.add_accessory('green hat')
+    @potato_head.add_accessory('red shoes')
+
+    expected = "accessories:\n\t- green hat\n\t- red shoes"
+    assert_equal(expected, @potato_head.accessories_to_s)
+  end
+
+  def test_accessories_string_empty
+    assert_nil(@potato_head.accessories_to_s)
+  end
+
+  def test_to_s
+    @potato_head.add_accessory('green hat')
+    @potato_head.add_accessory('red shoes')
+
+    expected = "accessories:\n\t- green hat\n\t- red shoes"
+    assert_equal(expected, @potato_head.to_s)
+  end
+end

--- a/Ruby/Week 8/Accessorize/tests/shirt_test.rb
+++ b/Ruby/Week 8/Accessorize/tests/shirt_test.rb
@@ -1,0 +1,60 @@
+require 'minitest/autorun'
+require_relative '../shirt'
+
+class ShirtTest < Minitest::Test
+  def setup
+    @shirt = Shirt.new('Tshirt', 'green')
+  end
+
+  def test_shirt_initialized
+    assert_equal('Tshirt', @shirt.name)
+  end
+
+  def test_add_accessory
+    @shirt.add_accessory('necklace')
+    expected = ['necklace']
+    assert_equal(expected, @shirt.accessories)
+  end
+
+  def test_add_multiple_accessories
+    @shirt.add_accessory('necklace')
+    @shirt.add_accessory('gold bracelet')
+    @shirt.add_accessory('silver bracelet')
+
+    expected = ['necklace', 'gold bracelet', 'silver bracelet']
+    assert_equal(expected, @shirt.accessories)
+  end
+
+  def test_remove_accessory
+    @shirt.add_accessory('necklace')
+    @shirt.remove_accessory('necklace')
+    expected = []
+    assert_equal(expected, @shirt.accessories)
+  end
+
+  def test_remove_accessory_that_does_not_exist
+    @shirt.remove_accessory('necklace')
+    expected = nil
+    assert_nil(@shirt.accessories)
+  end
+
+  def test_accessories_string
+    @shirt.add_accessory('necklace')
+    @shirt.add_accessory('bracelet')
+
+    expected = "accessories:\n\t- necklace\n\t- bracelet"
+    assert_equal(expected, @shirt.accessories_to_s)
+  end
+
+  def test_accessories_string_empty
+    assert_nil(@shirt.accessories_to_s)
+  end
+
+  def test_to_s
+    @shirt.add_accessory('necklace')
+    @shirt.add_accessory('bracelet')
+
+    expected = "A green Tshirt, with accessories:\n\t- necklace\n\t- bracelet"
+    assert_equal(expected, @shirt.to_s)
+  end
+end

--- a/Ruby/Week 8/Accessorize/tests/toy_test.rb
+++ b/Ruby/Week 8/Accessorize/tests/toy_test.rb
@@ -1,0 +1,17 @@
+require 'minitest/autorun'
+require_relative '../toy'
+
+class ToyTest < Minitest::Test
+  def setup
+    @toy = Toy.new('Lego Figure')
+  end
+
+  def test_toy_initialized
+    assert_equal("Lego Figure", @toy.name)
+  end
+
+  def test_to_s
+    expected = "This is a Lego Figure.\n"
+    assert_output(expected) { puts @toy.to_s }
+  end
+end

--- a/Ruby/Week 8/Accessorize/toy.rb
+++ b/Ruby/Week 8/Accessorize/toy.rb
@@ -1,0 +1,11 @@
+class Toy
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def to_s
+    "This is a #{name}."
+  end
+end


### PR DESCRIPTION
Adds an `Accessorizable` class to 2 separate class hierarchies (`Toys` & `Clothes`). This class allows for adding, removing and outputting the accessories to a string.

#### Class diagram:

![](https://screenshot.click/09-49-u0hgv-756lq.jpg)

#### Output

Example output of `accessories_to_s`:

![](https://screenshot.click/09-51-emnze-s7qjf.jpg)